### PR TITLE
Fix subscriptable type error for Python 3.8 and below

### DIFF
--- a/timescale_vector/client.py
+++ b/timescale_vector/client.py
@@ -196,7 +196,7 @@ class TimescaleVectorIndex(BaseIndex):
 
 # %% ../nbs/00_vector.ipynb 10
 class QueryParams:
-    def __init__(self, params: dict[str, Any]) -> None:
+    def __init__(self, params: Dict[str, Any]) -> None:
         self.params = params
     
     def get_statements(self) -> List[str]:


### PR DESCRIPTION
Changed the type hinting from dict and list to Dict and List from the typing module to fix a compatibility issue with Python 3.8 and earlier versions.